### PR TITLE
handle converting pr to/from draft

### DIFF
--- a/src/handlers/checkSuite.ts
+++ b/src/handlers/checkSuite.ts
@@ -12,7 +12,7 @@ export default (app: Probot) => {
 
     const pr = await PullRequest.getFromNumber(context, prNum);
 
-    if (pr.wip) return;
+    if (pr.wip || pr.data.draft) return;
 
     const suites = (
       await context.octokit.checks.listSuitesForRef({

--- a/src/labels.ts
+++ b/src/labels.ts
@@ -7,7 +7,7 @@ type Label = {
 
 export const labels: Record<string, Label> = {
   wip: {
-    regex: /^\[WIP\]\s/i,
+    regex: /^\s*(\[WIP\]\s*|WIP:\s*|WIP\s+)+/i,
     name: ':construction: WIP',
     color: '#FBCA04',
     description: 'Still under development, not yet ready for review',


### PR DESCRIPTION
The assumptions made here are:

- if a PR is a draft, we don't need the `[WIP]` title prefix
- if a PR is a draft, it will always be considered WIP so needs the WIP label
- if a PR is converted from a draft, it should be considered ready for review, and should update as such
- if a PR is converted back to a draft, it should drop the prefix for consistency and revert back to the WIP label
- if a PR is a draft we don't check for failing CI