### PR TITLE
reduce frequency of label presence checks

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,11 +1,13 @@
 import { Probot } from 'probot';
 
 import CheckSuite from './checkSuite.js';
+import Installation from './installation.js';
 import PullRequest from './pullRequest.js';
 import PullRequestReview from './pullRequestReview.js';
 
 export default (app: Probot) => {
   CheckSuite(app);
+  Installation(app);
   PullRequest(app);
   PullRequestReview(app);
 };

--- a/src/handlers/installation.ts
+++ b/src/handlers/installation.ts
@@ -1,0 +1,66 @@
+import { Probot, ProbotOctokit } from 'probot';
+
+import { labels } from '../labels.js';
+
+const ensureLabelsExist = async (
+  owner: string,
+  repo: string,
+  octokit: ProbotOctokit,
+) => {
+  const existingLabels = (
+    await octokit.issues.listLabelsForRepo({
+      owner,
+      repo,
+    })
+  ).data;
+
+  for (const label of Object.values(labels)) {
+    const existing = existingLabels.find(l => l.name === label.name);
+    const color = label.color.substring(1).toUpperCase();
+
+    if (!existing) {
+      await octokit.issues.createLabel({
+        owner,
+        repo,
+        name: label.name,
+        color,
+      });
+
+      continue;
+    }
+
+    if (existing.color.toUpperCase() !== color) {
+      await octokit.issues.updateLabel({
+        owner,
+        repo,
+        name: label.name,
+        color,
+      });
+
+      continue;
+    }
+  }
+};
+
+export default (app: Probot) => {
+  app.on(
+    [
+      'installation.created',
+      'installation.new_permissions_accepted',
+      'installation.unsuspend',
+      'installation_repositories.added',
+    ],
+    async context => {
+      const installationId = context.payload.installation.id;
+
+      const repos =
+        await context.octokit.apps.listReposAccessibleToInstallation({
+          installation_id: installationId,
+        });
+
+      for (const r of repos.data.repositories) {
+        await ensureLabelsExist(r.owner.login, r.name, context.octokit);
+      }
+    },
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import { Probot } from 'probot';
 
 import Handlers from './handlers/index.js';
-import { labels } from './labels.js';
 
 export default (app: Probot) => {
   /*
@@ -16,48 +15,6 @@ export default (app: Probot) => {
     });
   });
   */
-
-  app.on(
-    ['pull_request', 'pull_request_review', 'check_suite'],
-    async context => {
-      const owner = context.payload.repository.owner.login;
-      const repo = context.payload.repository.name;
-
-      const existingLabels = (
-        await context.octokit.issues.listLabelsForRepo({
-          owner,
-          repo,
-        })
-      ).data;
-
-      for (const label of Object.values(labels)) {
-        const existing = existingLabels.find(l => l.name === label.name);
-        const color = label.color.substring(1).toUpperCase();
-
-        if (!existing) {
-          await context.octokit.issues.createLabel({
-            owner,
-            repo,
-            name: label.name,
-            color,
-          });
-
-          continue;
-        }
-
-        if (existing.color.toUpperCase() !== color) {
-          await context.octokit.issues.updateLabel({
-            owner,
-            repo,
-            name: label.name,
-            color,
-          });
-
-          continue;
-        }
-      }
-    },
-  );
 
   app.log.info('probot loaded');
   Handlers(app);


### PR DESCRIPTION
Fixes #11 

This reduces the amount of times that the repo is checked to make sure the required labels are configured properly.

Runs on the following targets:
- New installation
- Installation is reinstated after being suspended
- New permissions are accepted (permission change is likely to come with a change to the labels)
- New repositories are added to the installation

I've selected these manually instad of a catch all as there's no need to run when repositories are deauthed, the installation is deleted/suspended and so on...

Consideration:
- If a new label is added without any of the above triggers, the label will be added to the repo on the next run it applies to, but will be not have the correct colour and will need to be fixed manually.