### PR TITLE
fix changesRequested label never clearing

### DIFF
--- a/src/classes/PullRequest.ts
+++ b/src/classes/PullRequest.ts
@@ -3,6 +3,11 @@ import { Context, ProbotOctokit } from 'probot';
 import { labels } from '../labels.js';
 
 type TContext = Context<'pull_request' | 'pull_request_review'>;
+type ReviewStatus =
+  | 'changesRequested'
+  | 'needsMoreApprovals'
+  | 'approved'
+  | 'readyForReview';
 
 type BarebonesContext = {
   octokit: ProbotOctokit;
@@ -104,9 +109,7 @@ export default class PullRequest {
     }
   }
 
-  async getReviewStatus(): Promise<
-    'changesRequested' | 'needsMoreApprovals' | 'approved' | undefined
-  > {
+  async getReviewStatus(): Promise<ReviewStatus> {
     const reviews = (
       await this.octokit.pulls.listReviews({
         owner: this.owner,
@@ -119,7 +122,7 @@ export default class PullRequest {
         ['APPROVED', 'CHANGES_REQUESTED'].includes(r.state),
     );
 
-    if (reviews.length < 1) return;
+    if (reviews.length < 1) return 'readyForReview';
 
     const latestReviewsObj: { [key: number]: { state: string; time: number } } =
       {};

--- a/src/handlers/pullRequest.ts
+++ b/src/handlers/pullRequest.ts
@@ -29,6 +29,16 @@ export default (app: Probot) => {
     }
   });
 
+  app.on(['pull_request.synchronize'], async context => {
+    const pr = new PullRequest(context);
+
+    if (pr.wip || pr.data.draft) return;
+
+    const reviewStatus = await pr.getReviewStatus();
+
+    await pr.addLabel(reviewStatus);
+  });
+
   app.on(['pull_request.closed'], async context => {
     const pr = new PullRequest(context);
 

--- a/src/handlers/pullRequestReview.ts
+++ b/src/handlers/pullRequestReview.ts
@@ -5,9 +5,10 @@ import PullRequest from '../classes/PullRequest.js';
 export default (app: Probot) => {
   app.on(['pull_request_review'], async context => {
     const pr = new PullRequest(context);
-    const reviewStatus = await pr.getReviewStatus();
 
-    if (!reviewStatus) return;
+    if (pr.wip || pr.data.draft) return;
+
+    const reviewStatus = await pr.getReviewStatus();
 
     await pr.addLabel(reviewStatus);
   });


### PR DESCRIPTION
Fixes #19 

It's not ideal but it does replicate the old behaviour. The bot will now treat all reviews as outdated if they're not against the latest commit.