### PR TITLE
Add webhook forwarder for GitHub security events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ lib
 .vscode
 
 .*.swp
+
+# Local Netlify folder
+.netlify

--- a/netlify/functions/security.ts
+++ b/netlify/functions/security.ts
@@ -1,0 +1,89 @@
+import { advisoryEmbed } from './../../src/security/advisoryEmbed';
+import { dependabotEmbed } from './../../src/security/dependabotEmbed';
+import { Handler } from '@netlify/functions';
+import { Webhooks } from '@octokit/webhooks';
+import { WebhookEventName } from '@octokit/webhooks/types';
+
+const postEmbed = async (targetWebhookUrl: string, embed: any) => {
+  const response = await fetch(targetWebhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ embeds: [embed] }),
+  });
+  if (!response.ok) {
+    console.error('Failed to send embed:', response.statusText);
+    const text = await response.text();
+    console.error('Response text:', text);
+    throw new Error(`Failed to send embed: ${response.statusText}`);
+  }
+  return response;
+};
+
+const handler: Handler = async event => {
+  try {
+    const webhooks = new Webhooks({
+      secret: process.env.GITHUB_WEBHOOK_SECRET || '',
+    });
+
+    const deliveryHeader = (event.headers['X-GitHub-Delivery'] ||
+      event.headers['x-github-delivery']) as string;
+    const nameHeader = (event.headers['X-GitHub-Event'] ||
+      event.headers['x-github-event']) as WebhookEventName;
+    const sigHeader = (event.headers['X-Hub-Signature-256'] ||
+      event.headers['x-hub-signature-256']) as string;
+
+    const targetWebhookUrl = event.queryStringParameters?.target;
+    if (!targetWebhookUrl) {
+      console.error('Missing target URL parameter');
+      return {
+        statusCode: 400,
+        body: 'Missing target URL parameter',
+      };
+    }
+
+    webhooks.on('dependabot_alert', ({ payload }) =>
+      postEmbed(targetWebhookUrl, dependabotEmbed(payload)),
+    );
+
+    webhooks.on('repository_advisory', ({ payload }) =>
+      postEmbed(targetWebhookUrl, advisoryEmbed(payload)),
+    );
+
+    webhooks.onAny(event => {
+      console.log('Received event:', event.name);
+    });
+
+    let errorMessage = '';
+    webhooks.onError(error => {
+      console.error('Webhook error:', error.message);
+      errorMessage = 'An error occurred while processing the webhook.';
+    });
+
+    await webhooks.verifyAndReceive({
+      id: deliveryHeader,
+      name: nameHeader,
+      signature: sigHeader,
+      payload: event.body ?? '',
+    });
+
+    if (errorMessage) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: errorMessage }),
+      };
+    }
+
+    return {
+      statusCode: 200,
+      body: '{"ok":true}',
+    };
+  } catch (error: any) {
+    console.error('Webhook error:', error);
+    return {
+      statusCode: error.status || error.statusCode || 500,
+      body: JSON.stringify({ error: 'Processing error' }),
+    };
+  }
+};
+
+export { handler };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:fix": "eslint --fix ."
   },
   "dependencies": {
+    "@octokit/webhooks": "^13.8.0",
     "probot": "^13.0.1"
   },
   "devDependencies": {

--- a/src/security/advisoryEmbed.ts
+++ b/src/security/advisoryEmbed.ts
@@ -1,0 +1,70 @@
+import type { components } from '@octokit/openapi-types';
+
+const getColourForSeverity = (severity: string | null): number => {
+  switch (severity) {
+    case 'critical':
+      return 0xff0000; // Red
+    case 'high':
+    case 'medium':
+      return 0xff8c00; // Orange
+    case 'low':
+      return 0xffff66; // Yellow
+    default:
+      return 0xff8c00; // Orange for unknown
+  }
+};
+
+export const advisoryEmbed = (
+  payload:
+    | components['schemas']['webhook-repository-advisory-reported']
+    | components['schemas']['webhook-repository-advisory-published'],
+) => {
+  const { repository, repository_advisory, action, sender } = payload;
+
+  const { owner, name: repoName, html_url } = repository;
+
+  const {
+    html_url: permalink,
+    severity,
+    summary,
+    author,
+  } = repository_advisory;
+
+  const initiator = author || sender;
+
+  return {
+    title:
+      action === 'reported' ? 'New Advisory Reported' : 'Advisory Published',
+    url: permalink,
+    description: summary,
+    color: action === 'reported' ? getColourForSeverity(severity) : 0xd3d3d3, // Red for reported, grey for published
+    fields: [
+      {
+        name: 'Action',
+        value: action,
+        inline: true,
+      },
+      {
+        name: 'Repository',
+        value: `[${owner.login}/${repoName}](${html_url})`,
+        inline: true,
+      },
+      {
+        name: 'Severity',
+        value: severity || 'Unknown',
+        inline: true,
+      },
+      {
+        name: 'Initiator',
+        value: initiator
+          ? `[${initiator.login}](${initiator.html_url})`
+          : 'Unknown',
+        inline: true,
+      },
+    ],
+    footer: {
+      text: 'Repository Advisories',
+    },
+    timestamp: new Date().toISOString(),
+  };
+};

--- a/src/security/dependabotEmbed.ts
+++ b/src/security/dependabotEmbed.ts
@@ -1,0 +1,112 @@
+import type { components } from '@octokit/openapi-types';
+
+const getColourForAction = (action: string): number => {
+  switch (action) {
+    case 'created':
+      return 0xff0000; // Red
+    case 'dismissed':
+    case 'auto_dismissed':
+      return 0xd3d3d3; // Light grey
+    case 'fixed':
+      return 0x00cc66; // Green
+    case 'reintroduced':
+      return 0xff8c00; // Orange
+    case 'reopened':
+    case 'auto_reopened':
+      return 0xffff66; // Yellow
+    default:
+      return 0x808080; // Fallback grey
+  }
+};
+
+const getTitleForAction = (action: string): string => {
+  switch (action) {
+    case 'created':
+      return 'Dependabot Alert';
+    case 'dismissed':
+      return 'Dependabot Alert Dismissed';
+    case 'auto_dismissed':
+      return 'Dependabot Alert Automatically Dismissed';
+    case 'fixed':
+      return 'Dependabot Alert Fixed';
+    case 'reintroduced':
+      return 'Dependabot Alert Reintroduced';
+    case 'reopened':
+      return 'Dependabot Alert Reopened';
+    case 'auto_reopened':
+      return 'Dependabot Alert Automatically Reopened';
+    default:
+      return 'Dependabot Alert';
+  }
+};
+
+export const dependabotEmbed = (
+  payload:
+    | components['schemas']['webhook-dependabot-alert-created']
+    | components['schemas']['webhook-dependabot-alert-dismissed']
+    | components['schemas']['webhook-dependabot-alert-auto-dismissed']
+    | components['schemas']['webhook-dependabot-alert-fixed']
+    | components['schemas']['webhook-dependabot-alert-reintroduced']
+    | components['schemas']['webhook-dependabot-alert-reopened']
+    | components['schemas']['webhook-dependabot-alert-auto-reopened'],
+) => {
+  const { repository, alert, action } = payload;
+
+  const { owner, name: repoName, html_url } = repository;
+
+  if (!alert || !alert.security_advisory) {
+    console.warn('No alert or security_advisory in payload');
+    return;
+  }
+
+  const {
+    security_advisory: { severity, summary },
+    html_url: permalink,
+    dependency,
+    dismissed_by,
+  } = alert;
+
+  const packageName = dependency?.package?.name;
+
+  return {
+    title: packageName
+      ? `${getTitleForAction(action)}: ${packageName}`
+      : getTitleForAction(action),
+    url: permalink,
+    description: summary,
+    color: getColourForAction(action),
+    fields: [
+      {
+        name: 'Action',
+        value: action,
+        inline: true,
+      },
+      {
+        name: 'Dependency',
+        value: packageName || 'Unknown',
+        inline: true,
+      },
+      {
+        name: 'Repository',
+        value: `[${owner.login}/${repoName}](${html_url})`,
+        inline: true,
+      },
+      {
+        name: 'Severity',
+        value: severity,
+        inline: true,
+      },
+      action === 'dismissed'
+        ? {
+            name: 'Dismissed By',
+            value: dismissed_by?.login || 'Unknown',
+            inline: true,
+          }
+        : null,
+    ].filter(Boolean),
+    footer: {
+      text: 'GitHub Dependabot',
+    },
+    timestamp: new Date().toISOString(),
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -472,6 +472,21 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-22.2.0.tgz#75aa7dcd440821d99def6a60b5f014207ae4968e"
   integrity sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==
 
+"@octokit/openapi-types@^24.2.0":
+  version "24.2.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-24.2.0.tgz#3d55c32eac0d38da1a7083a9c3b0cca77924f7d3"
+  integrity sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==
+
+"@octokit/openapi-types@^25.0.0":
+  version "25.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-25.0.0.tgz#adeead36992abf966e89dcd53518d8b0dc910e0d"
+  integrity sha512-FZvktFu7HfOIJf2BScLKIEYjDsw6RKc7rBJCdvCTfKsVnx2GEB/Nbzjr29DUdb7vQhlzS/j8qDzdditP0OC6aw==
+
+"@octokit/openapi-webhooks-types@10.4.0":
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-webhooks-types/-/openapi-webhooks-types-10.4.0.tgz#2cf1e08b9ad9f66930865c9e555499ae2e7507a3"
+  integrity sha512-HMiF7FUiVBYfp8pPijMTkWuPELQB6XkPftrnSuK1C1YXaaq2+0ganiQkorEQfXTmhtwlgHJwXT6P8miVhIyjQA==
+
 "@octokit/plugin-enterprise-compatibility@^4.0.1":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-enterprise-compatibility/-/plugin-enterprise-compatibility-4.1.0.tgz#9414961edc8e75fe75c0259fc16af59a68e98012"
@@ -511,7 +526,16 @@
     "@octokit/types" "^12.2.0"
     bottleneck "^2.15.3"
 
-"@octokit/request-error@^5.0.0", "@octokit/request-error@^5.1.0":
+"@octokit/request-error@^5.0.0":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-5.1.1.tgz#b9218f9c1166e68bb4d0c89b638edc62c9334805"
+  integrity sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==
+  dependencies:
+    "@octokit/types" "^13.1.0"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request-error@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-5.1.0.tgz#ee4138538d08c81a60be3f320cd71063064a3b30"
   integrity sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==
@@ -519,6 +543,13 @@
     "@octokit/types" "^13.1.0"
     deprecation "^2.0.0"
     once "^1.4.0"
+
+"@octokit/request-error@^6.1.7":
+  version "6.1.8"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-6.1.8.tgz#3c7ce1ca6721eabd43dbddc76b44860de1fdea75"
+  integrity sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==
+  dependencies:
+    "@octokit/types" "^14.0.0"
 
 "@octokit/request@^8.1.6", "@octokit/request@^8.3.0", "@octokit/request@^8.3.1":
   version "8.4.0"
@@ -537,22 +568,41 @@
   dependencies:
     "@octokit/openapi-types" "^20.0.0"
 
-"@octokit/types@^13.0.0", "@octokit/types@^13.1.0", "@octokit/types@^13.5.0":
+"@octokit/types@^13.0.0", "@octokit/types@^13.5.0":
   version "13.5.0"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-13.5.0.tgz#4796e56b7b267ebc7c921dcec262b3d5bfb18883"
   integrity sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==
   dependencies:
     "@octokit/openapi-types" "^22.2.0"
 
+"@octokit/types@^13.1.0":
+  version "13.10.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-13.10.0.tgz#3e7c6b19c0236c270656e4ea666148c2b51fd1a3"
+  integrity sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==
+  dependencies:
+    "@octokit/openapi-types" "^24.2.0"
+
+"@octokit/types@^14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-14.0.0.tgz#bbd1d31e2269940789ef143b1c37918aae09adc4"
+  integrity sha512-VVmZP0lEhbo2O1pdq63gZFiGCKkm8PPp8AUOijlwPO6hojEVjspA0MWKP7E4hbvGxzFKNqKr6p0IYtOH/Wf/zA==
+  dependencies:
+    "@octokit/openapi-types" "^25.0.0"
+
 "@octokit/webhooks-methods@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@octokit/webhooks-methods/-/webhooks-methods-4.1.0.tgz#681a6c86c9b21d4ec9e29108fb053ae7512be033"
   integrity sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==
 
-"@octokit/webhooks-types@7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-7.4.0.tgz#7ed15c75908683a34e0079c80f261fe568b87395"
-  integrity sha512-FE2V+QZ2UYlh+9wWd5BPLNXG+J/XUD/PPq0ovS+nCcGX4+3qVbi3jYOmCTW48hg9SBBLtInx9+o7fFt4H5iP0Q==
+"@octokit/webhooks-methods@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-methods/-/webhooks-methods-5.1.1.tgz#192f11a1f115702833f033293e2fef8f69f612e4"
+  integrity sha512-NGlEHZDseJTCj8TMMFehzwa9g7On4KJMPVHDSrHxCQumL6uSQR8wIkP/qesv52fXqV1BPf4pTxwtS31ldAt9Xg==
+
+"@octokit/webhooks-types@7.6.1":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz#bc96371057c2d54c982c9f8f642655b26cd588eb"
+  integrity sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==
 
 "@octokit/webhooks-types@^7.5.1":
   version "7.5.1"
@@ -560,14 +610,23 @@
   integrity sha512-1dozxWEP8lKGbtEu7HkRbK1F/nIPuJXNfT0gd96y6d3LcHZTtRtlf8xz3nicSJfesADxJyDh+mWBOsdLkqgzYw==
 
 "@octokit/webhooks@^12.0.10":
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-12.2.0.tgz#ea1ee2d9d9c5a4b7b53ff8bc64a9feb0dac94161"
-  integrity sha512-CyuLJ0/P7bKZ+kIYw+fnkeVdhUzNuDKgNSI7pU/m7Nod0T7kP+s4s2f0pNmG9HL8/RZN1S0ZWTDll3VTMrFLAw==
+  version "12.3.1"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-12.3.1.tgz#fd4de89ccb0560475411503951ce6469488c63a7"
+  integrity sha512-BVwtWE3rRXB9IugmQTfKspqjNa8q+ab73ddkV9k1Zok3XbuOxJUi4lTYk5zBZDhfWb/Y2H+RO9Iggm25gsqeow==
   dependencies:
     "@octokit/request-error" "^5.0.0"
     "@octokit/webhooks-methods" "^4.1.0"
-    "@octokit/webhooks-types" "7.4.0"
+    "@octokit/webhooks-types" "7.6.1"
     aggregate-error "^3.1.0"
+
+"@octokit/webhooks@^13.8.0":
+  version "13.8.0"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks/-/webhooks-13.8.0.tgz#0d1f40f5b4217090deb5b810426052f477d8522b"
+  integrity sha512-3PCWyFBNbW2+Ox36VAkSqlPoIb96NZiPcICRYySHZrDTM2NuNxvrjPeaQDj2egqILs9EZFObRTHVMe4XxXJV7w==
+  dependencies:
+    "@octokit/openapi-webhooks-types" "10.4.0"
+    "@octokit/request-error" "^6.1.7"
+    "@octokit/webhooks-methods" "^5.1.1"
 
 "@opentelemetry/api-logs@0.52.1":
   version "0.52.1"
@@ -3408,7 +3467,16 @@ std-env@^3.7.0:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.7.0.tgz#c9f7386ced6ecf13360b6c6c55b8aaa4ef7481d2"
   integrity sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3433,7 +3501,14 @@ string_decoder@^1.1.1, string_decoder@^1.3.0:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3726,7 +3801,16 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
As it says on the tin. This is necessary because unfortunately Discord doesn't implement the security-related events for webhooks, so we have to manually construct them. Wondering if you think it's okay to reuse this repo! The code does fit the shape of "webhook on a GitHub event" but on the other hand it's not a GitHub app in the same sense. Open to creating another repo instead if we decide it's merited.