### PR TITLE
prevent label changes when the body of the PR is edited

### DIFF
--- a/src/handlers/pullRequest.ts
+++ b/src/handlers/pullRequest.ts
@@ -20,7 +20,15 @@ export default (app: Probot) => {
   app.on(['pull_request.edited'], async context => {
     const pr = new PullRequest(context);
 
-    if (pr.data.state === 'closed' || pr.data.draft) return;
+    if (
+      pr.data.state === 'closed' ||
+      pr.data.draft ||
+      // the previous title is set here if the title was updated
+      // this screens out edits to the body
+      context.payload.changes?.title?.from == null
+    ) {
+      return;
+    }
 
     if (pr.wip) {
       await pr.addLabel('wip');


### PR DESCRIPTION
See https://github.com/actualbudget/actual/pull/5448 for an example of incorrect labelling

There's an argument here to refactor this whole bot to take a PR and calculate the correct label from its current state, regardless of what webhook event triggered it. It's less efficient though and it's been working pretty well so far so I'll leave it for now.