### PR TITLE
feat: Auto-assign maintainers to PRs on comment/review

### DIFF
--- a/src/classes/PullRequest.ts
+++ b/src/classes/PullRequest.ts
@@ -2,7 +2,9 @@ import { Context, ProbotOctokit } from 'probot';
 
 import { labels } from '../labels.js';
 
-type TContext = Context<'pull_request' | 'pull_request_review'>;
+type TContext = Context<
+  'pull_request' | 'pull_request_review' | 'pull_request_review_comment'
+>;
 type ReviewStatus =
   | 'changesRequested'
   | 'needsMoreApprovals'
@@ -194,5 +196,26 @@ export default class PullRequest {
     }
 
     return 'readyForReview';
+  }
+
+  async isOrgMember(username: string): Promise<boolean> {
+    try {
+      await this.octokit.orgs.checkMembershipForUser({
+        org: 'actualbudget',
+        username,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async addAssignee(username: string) {
+    await this.octokit.issues.addAssignees({
+      owner: this.owner,
+      repo: this.repo,
+      issue_number: this.number,
+      assignees: [username],
+    });
   }
 }

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -2,12 +2,16 @@ import { Probot } from 'probot';
 
 import CheckSuite from './checkSuite.js';
 import Installation from './installation.js';
+import IssueComment from './issueComment.js';
 import PullRequest from './pullRequest.js';
 import PullRequestReview from './pullRequestReview.js';
+import PullRequestReviewComment from './pullRequestReviewComment.js';
 
 export default (app: Probot) => {
   CheckSuite(app);
   Installation(app);
+  IssueComment(app);
   PullRequest(app);
   PullRequestReview(app);
+  PullRequestReviewComment(app);
 };

--- a/src/handlers/issueComment.ts
+++ b/src/handlers/issueComment.ts
@@ -1,0 +1,23 @@
+import { Probot } from 'probot';
+
+import PullRequest from '../classes/PullRequest.js';
+
+export default (app: Probot) => {
+  app.on(['issue_comment.created'], async context => {
+    // Only handle comments on pull requests (not issues)
+    if (!context.payload.issue.pull_request) return;
+
+    const commenter = context.payload.comment.user?.login;
+    if (!commenter) return;
+
+    const pr = await PullRequest.getFromNumber(
+      context,
+      context.payload.issue.number,
+    );
+
+    const isMember = await pr.isOrgMember(commenter);
+    if (!isMember) return;
+
+    await pr.addAssignee(commenter);
+  });
+};

--- a/src/handlers/pullRequestReview.ts
+++ b/src/handlers/pullRequestReview.ts
@@ -6,6 +6,15 @@ export default (app: Probot) => {
   app.on(['pull_request_review'], async context => {
     const pr = new PullRequest(context);
 
+    // Auto-assign reviewer if they are an org member
+    const reviewer = context.payload.review.user?.login;
+    if (reviewer) {
+      const isMember = await pr.isOrgMember(reviewer);
+      if (isMember) {
+        await pr.addAssignee(reviewer);
+      }
+    }
+
     if (pr.wip || pr.data.draft) return;
 
     const reviewStatus = await pr.getReviewStatus();

--- a/src/handlers/pullRequestReview.ts
+++ b/src/handlers/pullRequestReview.ts
@@ -11,7 +11,11 @@ export default (app: Probot) => {
     if (reviewer) {
       const isMember = await pr.isOrgMember(reviewer);
       if (isMember) {
-        await pr.addAssignee(reviewer);
+        try {
+          await pr.addAssignee(reviewer);
+        } catch {
+          // Ignore errors - don't break review labeling if assignment fails
+        }
       }
     }
 

--- a/src/handlers/pullRequestReviewComment.ts
+++ b/src/handlers/pullRequestReviewComment.ts
@@ -1,0 +1,17 @@
+import { Probot } from 'probot';
+
+import PullRequest from '../classes/PullRequest.js';
+
+export default (app: Probot) => {
+  app.on(['pull_request_review_comment.created'], async context => {
+    const commenter = context.payload.comment.user?.login;
+    if (!commenter) return;
+
+    const pr = new PullRequest(context);
+
+    const isMember = await pr.isOrgMember(commenter);
+    if (!isMember) return;
+
+    await pr.addAssignee(commenter);
+  });
+};

--- a/test/autoAssign/issueComment.test.ts
+++ b/test/autoAssign/issueComment.test.ts
@@ -1,0 +1,114 @@
+import { describe, beforeEach, afterEach, test, expect } from 'vitest';
+import fs from 'fs';
+import nock from 'nock';
+import path from 'path';
+
+import { setupProbot, teardownProbot } from '../testHelpers';
+
+const issueCommentPayload = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, '../fixtures/issue_comment.json'),
+    'utf-8',
+  ),
+);
+
+const pullRequestPayload = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, '../fixtures/pull_request.json'),
+    'utf-8',
+  ),
+);
+
+describe('Issue Comment Auto-Assign', () => {
+  let probot: any;
+
+  beforeEach(() => {
+    probot = setupProbot();
+  });
+
+  afterEach(() => {
+    teardownProbot();
+  });
+
+  test('assigns maintainer when they comment on a PR', async () => {
+    const mock = nock('https://api.github.com')
+      .post('/app/installations/2/access_tokens')
+      .reply(200, {
+        token: 'test',
+        permissions: {
+          pull_requests: 'write',
+        },
+      })
+      .get('/repos/your-repo/your-repo-name/pulls/1')
+      .reply(200, pullRequestPayload.pull_request)
+      .get('/orgs/actualbudget/members/maintainer-user')
+      .reply(204)
+      .post(
+        '/repos/your-repo/your-repo-name/issues/1/assignees',
+        (body: any) => {
+          expect(body).toMatchObject({ assignees: ['maintainer-user'] });
+          return true;
+        },
+      )
+      .reply(200);
+
+    await probot.receive({
+      name: 'issue_comment',
+      payload: issueCommentPayload,
+    });
+
+    expect(mock.pendingMocks()).toStrictEqual([]);
+  });
+
+  test('does not assign non-maintainer when they comment on a PR', async () => {
+    const mock = nock('https://api.github.com')
+      .post('/app/installations/2/access_tokens')
+      .reply(200, {
+        token: 'test',
+        permissions: {
+          pull_requests: 'write',
+        },
+      })
+      .get('/repos/your-repo/your-repo-name/pulls/1')
+      .reply(200, pullRequestPayload.pull_request)
+      .get('/orgs/actualbudget/members/maintainer-user')
+      .reply(404);
+
+    const errorMock = nock('https://api.github.com')
+      .post('/repos/your-repo/your-repo-name/issues/1/assignees')
+      .reply(() => {
+        throw new Error('Assignee should not be called for non-maintainers');
+      });
+
+    await probot.receive({
+      name: 'issue_comment',
+      payload: issueCommentPayload,
+    });
+
+    expect(mock.pendingMocks()).toStrictEqual([]);
+    expect(errorMock.isDone()).toBe(false);
+  });
+
+  test('ignores comments on issues (not PRs)', async () => {
+    const issueOnlyPayload = {
+      ...issueCommentPayload,
+      issue: {
+        ...issueCommentPayload.issue,
+        pull_request: undefined,
+      },
+    };
+
+    const errorMock = nock('https://api.github.com')
+      .get('/orgs/actualbudget/members/maintainer-user')
+      .reply(() => {
+        throw new Error('Org membership should not be checked for issues');
+      });
+
+    await probot.receive({
+      name: 'issue_comment',
+      payload: issueOnlyPayload,
+    });
+
+    expect(errorMock.isDone()).toBe(false);
+  });
+});

--- a/test/autoAssign/pullRequestReview.test.ts
+++ b/test/autoAssign/pullRequestReview.test.ts
@@ -1,0 +1,88 @@
+import { describe, beforeEach, afterEach, test, expect } from 'vitest';
+import fs from 'fs';
+import nock from 'nock';
+import path from 'path';
+
+import { setupProbot, teardownProbot } from '../testHelpers';
+
+const pullRequestReviewPayload = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, '../fixtures/pull_request_review.json'),
+    'utf-8',
+  ),
+);
+
+describe('Pull Request Review Auto-Assign', () => {
+  let probot: any;
+
+  beforeEach(() => {
+    probot = setupProbot();
+  });
+
+  afterEach(() => {
+    teardownProbot();
+  });
+
+  test('assigns maintainer when they submit a review', async () => {
+    const mock = nock('https://api.github.com')
+      .post('/app/installations/2/access_tokens')
+      .reply(200, {
+        token: 'test',
+        permissions: {
+          pull_requests: 'write',
+        },
+      })
+      .get('/orgs/actualbudget/members/maintainer-user')
+      .reply(204)
+      .post(
+        '/repos/your-repo/your-repo-name/issues/1/assignees',
+        (body: any) => {
+          expect(body).toMatchObject({ assignees: ['maintainer-user'] });
+          return true;
+        },
+      )
+      .reply(200)
+      .get('/repos/your-repo/your-repo-name/pulls/1/reviews')
+      .reply(200, [])
+      .put('/repos/your-repo/your-repo-name/issues/1/labels')
+      .reply(200);
+
+    await probot.receive({
+      name: 'pull_request_review',
+      payload: pullRequestReviewPayload,
+    });
+
+    expect(mock.pendingMocks()).toStrictEqual([]);
+  });
+
+  test('does not assign non-maintainer when they submit a review', async () => {
+    const mock = nock('https://api.github.com')
+      .post('/app/installations/2/access_tokens')
+      .reply(200, {
+        token: 'test',
+        permissions: {
+          pull_requests: 'write',
+        },
+      })
+      .get('/orgs/actualbudget/members/maintainer-user')
+      .reply(404)
+      .get('/repos/your-repo/your-repo-name/pulls/1/reviews')
+      .reply(200, [])
+      .put('/repos/your-repo/your-repo-name/issues/1/labels')
+      .reply(200);
+
+    const errorMock = nock('https://api.github.com')
+      .post('/repos/your-repo/your-repo-name/issues/1/assignees')
+      .reply(() => {
+        throw new Error('Assignee should not be called for non-maintainers');
+      });
+
+    await probot.receive({
+      name: 'pull_request_review',
+      payload: pullRequestReviewPayload,
+    });
+
+    expect(mock.pendingMocks()).toStrictEqual([]);
+    expect(errorMock.isDone()).toBe(false);
+  });
+});

--- a/test/autoAssign/pullRequestReviewComment.test.ts
+++ b/test/autoAssign/pullRequestReviewComment.test.ts
@@ -1,0 +1,80 @@
+import { describe, beforeEach, afterEach, test, expect } from 'vitest';
+import fs from 'fs';
+import nock from 'nock';
+import path from 'path';
+
+import { setupProbot, teardownProbot } from '../testHelpers';
+
+const pullRequestReviewCommentPayload = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, '../fixtures/pull_request_review_comment.json'),
+    'utf-8',
+  ),
+);
+
+describe('Pull Request Review Comment Auto-Assign', () => {
+  let probot: any;
+
+  beforeEach(() => {
+    probot = setupProbot();
+  });
+
+  afterEach(() => {
+    teardownProbot();
+  });
+
+  test('assigns maintainer when they leave a line comment', async () => {
+    const mock = nock('https://api.github.com')
+      .post('/app/installations/2/access_tokens')
+      .reply(200, {
+        token: 'test',
+        permissions: {
+          pull_requests: 'write',
+        },
+      })
+      .get('/orgs/actualbudget/members/maintainer-user')
+      .reply(204)
+      .post(
+        '/repos/your-repo/your-repo-name/issues/1/assignees',
+        (body: any) => {
+          expect(body).toMatchObject({ assignees: ['maintainer-user'] });
+          return true;
+        },
+      )
+      .reply(200);
+
+    await probot.receive({
+      name: 'pull_request_review_comment',
+      payload: pullRequestReviewCommentPayload,
+    });
+
+    expect(mock.pendingMocks()).toStrictEqual([]);
+  });
+
+  test('does not assign non-maintainer when they leave a line comment', async () => {
+    const mock = nock('https://api.github.com')
+      .post('/app/installations/2/access_tokens')
+      .reply(200, {
+        token: 'test',
+        permissions: {
+          pull_requests: 'write',
+        },
+      })
+      .get('/orgs/actualbudget/members/maintainer-user')
+      .reply(404);
+
+    const errorMock = nock('https://api.github.com')
+      .post('/repos/your-repo/your-repo-name/issues/1/assignees')
+      .reply(() => {
+        throw new Error('Assignee should not be called for non-maintainers');
+      });
+
+    await probot.receive({
+      name: 'pull_request_review_comment',
+      payload: pullRequestReviewCommentPayload,
+    });
+
+    expect(mock.pendingMocks()).toStrictEqual([]);
+    expect(errorMock.isDone()).toBe(false);
+  });
+});

--- a/test/fixtures/issue_comment.json
+++ b/test/fixtures/issue_comment.json
@@ -1,0 +1,27 @@
+{
+  "action": "created",
+  "issue": {
+    "number": 1,
+    "pull_request": {
+      "url": "https://api.github.com/repos/your-repo/your-repo-name/pulls/1"
+    }
+  },
+  "comment": {
+    "id": 1,
+    "body": "Test comment",
+    "user": {
+      "login": "maintainer-user",
+      "id": 123
+    }
+  },
+  "repository": {
+    "name": "your-repo-name",
+    "owner": {
+      "login": "your-repo"
+    }
+  },
+  "installation": {
+    "id": 2
+  }
+}
+

--- a/test/fixtures/pull_request_review.json
+++ b/test/fixtures/pull_request_review.json
@@ -1,0 +1,34 @@
+{
+  "action": "submitted",
+  "review": {
+    "id": 1,
+    "state": "approved",
+    "user": {
+      "login": "maintainer-user",
+      "id": 123
+    }
+  },
+  "pull_request": {
+    "title": "Test Pull Request",
+    "number": 1,
+    "state": "open",
+    "draft": false,
+    "head": {
+      "sha": "abc123"
+    },
+    "base": {
+      "ref": "master"
+    },
+    "labels": []
+  },
+  "repository": {
+    "name": "your-repo-name",
+    "owner": {
+      "login": "your-repo"
+    }
+  },
+  "installation": {
+    "id": 2
+  }
+}
+

--- a/test/fixtures/pull_request_review_comment.json
+++ b/test/fixtures/pull_request_review_comment.json
@@ -1,0 +1,34 @@
+{
+  "action": "created",
+  "comment": {
+    "id": 1,
+    "body": "Test line comment",
+    "user": {
+      "login": "maintainer-user",
+      "id": 123
+    }
+  },
+  "pull_request": {
+    "title": "Test Pull Request",
+    "number": 1,
+    "state": "open",
+    "draft": false,
+    "head": {
+      "sha": "abc123"
+    },
+    "base": {
+      "ref": "master"
+    },
+    "labels": []
+  },
+  "repository": {
+    "name": "your-repo-name",
+    "owner": {
+      "login": "your-repo"
+    }
+  },
+  "installation": {
+    "id": 2
+  }
+}
+


### PR DESCRIPTION
## Summary

When a member of the `actualbudget` organization comments on or reviews a PR (including PRs from forks), they are automatically assigned to that PR.

## Changes

### New Handlers
- **`issueComment.ts`** - Handles `issue_comment.created` events for PR comments
- **`pullRequestReviewComment.ts`** - Handles `pull_request_review_comment.created` events for line-level review comments

### Modified Files
- **`pullRequestReview.ts`** - Extended to auto-assign reviewers when they submit a review
- **`PullRequest.ts`** - Added `isOrgMember()` and `addAssignee()` helper methods
- **`handlers/index.ts`** - Registered new handlers

## How It Works

1. When a comment/review event is received, we check if the user is a member of the `actualbudget` organization using `orgs.checkMembershipForUser`
2. If they are a member, we assign them to the PR using `issues.addAssignees`

## Testing

Added comprehensive tests covering:
- Maintainer commenting on PR → gets assigned
- Non-maintainer commenting on PR → not assigned
- Comments on issues (not PRs) → ignored
- PR reviews and line comments follow the same pattern

All 20 tests pass ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Auto-assigns `actualbudget` org members to PRs when they comment, leave review comments, or submit reviews, with handlers registered and tests added.
> 
> - **Core**
>   - Extend `TContext` to include `pull_request_review_comment` in `src/classes/PullRequest.ts`.
>   - Add helpers `isOrgMember(username)` and `addAssignee(username)` in `src/classes/PullRequest.ts`.
> - **Handlers**
>   - New `src/handlers/issueComment.ts` to assign commenter on `issue_comment.created` (PRs only).
>   - New `src/handlers/pullRequestReviewComment.ts` to assign line commenters on `pull_request_review_comment.created`.
>   - Update `src/handlers/pullRequestReview.ts` to auto-assign reviewer if org member; keep review-labeling flow.
>   - Register new handlers in `src/handlers/index.ts`.
> - **Tests**
>   - Add `test/autoAssign/*` covering maintainer vs non-maintainer behavior and ignoring issue-only comments, with new fixtures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9eebac45b99aebe8769dd847c9ff8be79ed1718e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->