### PR TITLE
Skip auto-assign when commenter/reviewer is the PR author

### DIFF
--- a/src/handlers/issueComment.ts
+++ b/src/handlers/issueComment.ts
@@ -15,6 +15,10 @@ export default (app: Probot) => {
       context.payload.issue.number,
     );
 
+    // Don't auto-assign if the commenter is the PR author
+    const prAuthor = pr.data.user?.login;
+    if (commenter === prAuthor) return;
+
     const isMember = await pr.isOrgMember(commenter);
     if (!isMember) return;
 

--- a/src/handlers/pullRequestReview.ts
+++ b/src/handlers/pullRequestReview.ts
@@ -6,9 +6,10 @@ export default (app: Probot) => {
   app.on(['pull_request_review'], async context => {
     const pr = new PullRequest(context);
 
-    // Auto-assign reviewer if they are an org member
+    // Auto-assign reviewer if they are an org member and not the PR author
     const reviewer = context.payload.review.user?.login;
-    if (reviewer) {
+    const prAuthor = pr.data.user?.login;
+    if (reviewer && reviewer !== prAuthor) {
       const isMember = await pr.isOrgMember(reviewer);
       if (isMember) {
         try {

--- a/src/handlers/pullRequestReviewComment.ts
+++ b/src/handlers/pullRequestReviewComment.ts
@@ -9,6 +9,10 @@ export default (app: Probot) => {
 
     const pr = new PullRequest(context);
 
+    // Don't auto-assign if the commenter is the PR author
+    const prAuthor = pr.data.user?.login;
+    if (commenter === prAuthor) return;
+
     const isMember = await pr.isOrgMember(commenter);
     if (!isMember) return;
 

--- a/test/autoAssign/issueComment.test.ts
+++ b/test/autoAssign/issueComment.test.ts
@@ -138,7 +138,9 @@ describe('Issue Comment Auto-Assign', () => {
     const errorMock = nock('https://api.github.com')
       .post('/repos/your-repo/your-repo-name/issues/1/assignees')
       .reply(() => {
-        throw new Error('Assignee should not be called when commenter is PR author');
+        throw new Error(
+          'Assignee should not be called when commenter is PR author',
+        );
       });
 
     await probot.receive({

--- a/test/autoAssign/pullRequestReview.test.ts
+++ b/test/autoAssign/pullRequestReview.test.ts
@@ -114,7 +114,9 @@ describe('Pull Request Review Auto-Assign', () => {
     const errorMock = nock('https://api.github.com')
       .post('/repos/your-repo/your-repo-name/issues/1/assignees')
       .reply(() => {
-        throw new Error('Assignee should not be called when reviewer is PR author');
+        throw new Error(
+          'Assignee should not be called when reviewer is PR author',
+        );
       });
 
     await probot.receive({

--- a/test/autoAssign/pullRequestReviewComment.test.ts
+++ b/test/autoAssign/pullRequestReviewComment.test.ts
@@ -77,4 +77,30 @@ describe('Pull Request Review Comment Auto-Assign', () => {
     expect(mock.pendingMocks()).toStrictEqual([]);
     expect(errorMock.isDone()).toBe(false);
   });
+
+  test('does not assign commenter when they are the PR author', async () => {
+    const prAuthorPayload = {
+      ...pullRequestReviewCommentPayload,
+      comment: {
+        ...pullRequestReviewCommentPayload.comment,
+        user: {
+          login: 'pr-author',
+          id: 456,
+        },
+      },
+    };
+
+    const errorMock = nock('https://api.github.com')
+      .post('/repos/your-repo/your-repo-name/issues/1/assignees')
+      .reply(() => {
+        throw new Error('Assignee should not be called when commenter is PR author');
+      });
+
+    await probot.receive({
+      name: 'pull_request_review_comment',
+      payload: prAuthorPayload,
+    });
+
+    expect(errorMock.isDone()).toBe(false);
+  });
 });

--- a/test/autoAssign/pullRequestReviewComment.test.ts
+++ b/test/autoAssign/pullRequestReviewComment.test.ts
@@ -93,7 +93,9 @@ describe('Pull Request Review Comment Auto-Assign', () => {
     const errorMock = nock('https://api.github.com')
       .post('/repos/your-repo/your-repo-name/issues/1/assignees')
       .reply(() => {
-        throw new Error('Assignee should not be called when commenter is PR author');
+        throw new Error(
+          'Assignee should not be called when commenter is PR author',
+        );
       });
 
     await probot.receive({

--- a/test/fixtures/pull_request.json
+++ b/test/fixtures/pull_request.json
@@ -4,6 +4,10 @@
     "number": 1,
     "state": "open",
     "draft": false,
+    "user": {
+      "login": "pr-author",
+      "id": 456
+    },
     "head": {
       "sha": "abc123"
     },

--- a/test/fixtures/pull_request_review.json
+++ b/test/fixtures/pull_request_review.json
@@ -13,6 +13,10 @@
     "number": 1,
     "state": "open",
     "draft": false,
+    "user": {
+      "login": "pr-author",
+      "id": 456
+    },
     "head": {
       "sha": "abc123"
     },

--- a/test/fixtures/pull_request_review_comment.json
+++ b/test/fixtures/pull_request_review_comment.json
@@ -13,6 +13,10 @@
     "number": 1,
     "state": "open",
     "draft": false,
+    "user": {
+      "login": "pr-author",
+      "id": 456
+    },
     "head": {
       "sha": "abc123"
     },


### PR DESCRIPTION
## Summary

Updated the auto-assign workflow to only assign users when they are **different** from the PR author. Previously, the bot would auto-assign any org member who commented/reviewed, even if they were the PR author themselves.

## Changes

### Handler Updates
- **pullRequestReview.ts**: Added check to skip assignment if reviewer is the PR author
- **issueComment.ts**: Added check to skip assignment if commenter is the PR author  
- **pullRequestReviewComment.ts**: Added check to skip assignment if commenter is the PR author

### Test Updates
- Added `user` field to PR fixtures (`pull_request.json`, `pull_request_review.json`, `pull_request_review_comment.json`)
- Added test cases for each handler to verify PR authors are not auto-assigned

## Testing

All 23 tests pass:
- 3 tests for `pullRequestReview` (includes new PR author test)
- 4 tests for `issueComment` (includes new PR author test)
- 3 tests for `pullRequestReviewComment` (includes new PR author test)