### PR TITLE
refactor to recalculate labels from current PR state when triggered

### DIFF
--- a/src/handlers/checkSuite.ts
+++ b/src/handlers/checkSuite.ts
@@ -1,46 +1,14 @@
 import { Probot } from 'probot';
 
-import { checkFeatureFlag } from '../config.js';
 import PullRequest from '../classes/PullRequest.js';
+import { syncPullRequestLabels } from '../labels/labelCalculator.js';
 
 export default (app: Probot) => {
   app.on(['check_suite.completed'], async context => {
-    if (!(await checkFeatureFlag(context, 'enableFailingCI'))) return;
-
     const commitSha = context.payload.check_suite.head_sha;
     const prNum = context.payload.check_suite.pull_requests[0].number;
 
     const pr = await PullRequest.getFromNumber(context, prNum);
-
-    if (pr.wip || pr.data.draft) return;
-
-    const suites = (
-      await context.octokit.checks.listSuitesForRef({
-        owner: pr.owner,
-        repo: pr.repo,
-        ref: commitSha,
-      })
-    ).data.check_suites;
-
-    const runs = [];
-    for (const suite of suites) {
-      const run = (
-        await context.octokit.checks.listForSuite({
-          owner: pr.owner,
-          repo: pr.repo,
-          check_suite_id: suite.id,
-        })
-      ).data.check_runs;
-
-      runs.push(...run);
-    }
-
-    const failed = runs.some(r => r.conclusion === 'failure');
-
-    if (failed) {
-      await pr.addLabel('failingCI');
-    } else {
-      await pr.addLabel('readyForReview');
-    }
+    await syncPullRequestLabels(context, pr, { failingCiSha: commitSha });
   });
 };

--- a/src/handlers/pullRequestReview.ts
+++ b/src/handlers/pullRequestReview.ts
@@ -1,6 +1,7 @@
 import { Probot } from 'probot';
 
 import PullRequest from '../classes/PullRequest.js';
+import { syncPullRequestLabels } from '../labels/labelCalculator.js';
 
 export default (app: Probot) => {
   app.on(['pull_request_review'], async context => {
@@ -20,10 +21,6 @@ export default (app: Probot) => {
       }
     }
 
-    if (pr.wip || pr.data.draft) return;
-
-    const reviewStatus = await pr.getReviewStatus();
-
-    await pr.addLabel(reviewStatus);
+    await syncPullRequestLabels(context, pr);
   });
 };

--- a/src/labels/labelCalculator.ts
+++ b/src/labels/labelCalculator.ts
@@ -1,0 +1,52 @@
+import { Context } from 'probot';
+
+import PullRequest from '../classes/PullRequest.js';
+import { checkFeatureFlag } from '../config.js';
+import { labels } from '../labels.js';
+
+export type LabelKey = keyof typeof labels;
+
+type LabelCalcOptions = {
+  failingCiSha?: string;
+};
+
+export async function calculateRequiredLabels(
+  pr: PullRequest,
+  options: { includeFailingCI: boolean; failingCiSha?: string },
+): Promise<LabelKey[]> {
+  if (pr.data.state === 'closed') {
+    if (pr.data.merged_at != null) return ['merged'];
+    return [];
+  }
+
+  if (pr.data.draft || pr.wip) {
+    return ['wip'];
+  }
+
+  if (options.includeFailingCI) {
+    const hasFailure = await pr.hasFailingCI(options.failingCiSha);
+    if (hasFailure) return ['failingCI'];
+  }
+
+  const reviewStatus = await pr.getReviewStatus();
+  return [reviewStatus];
+}
+
+export async function syncPullRequestLabels(
+  context: Context,
+  pr: PullRequest,
+  options: LabelCalcOptions = {},
+) {
+  const includeFailingCI = await checkFeatureFlag(context, 'enableFailingCI');
+  const requiredLabels = await calculateRequiredLabels(pr, {
+    includeFailingCI,
+    failingCiSha: options.failingCiSha,
+  });
+
+  if (requiredLabels.length === 0) {
+    await pr.clearLabels();
+    return;
+  }
+
+  await pr.setLabelsByKeys(requiredLabels);
+}

--- a/src/labels/labelCalculator.ts
+++ b/src/labels/labelCalculator.ts
@@ -23,12 +23,18 @@ export async function calculateRequiredLabels(
     return ['wip'];
   }
 
+  const reviewStatus = await pr.getReviewStatus();
+
   if (options.includeFailingCI) {
     const hasFailure = await pr.hasFailingCI(options.failingCiSha);
-    if (hasFailure) return ['failingCI'];
+    if (hasFailure) {
+      if (reviewStatus === 'approved') {
+        return ['approved', 'failingCI'];
+      }
+      return ['failingCI'];
+    }
   }
 
-  const reviewStatus = await pr.getReviewStatus();
   return [reviewStatus];
 }
 

--- a/test/checkSuite/checkSuite.test.ts
+++ b/test/checkSuite/checkSuite.test.ts
@@ -1,0 +1,110 @@
+import { describe, afterEach, test, expect } from 'vitest';
+import nock from 'nock';
+
+import { setupProbot, teardownProbot } from '../testHelpers';
+import { labels } from '../../src/labels.js';
+
+const checkSuitePayload = {
+  action: 'completed',
+  check_suite: {
+    head_sha: 'abc123',
+    pull_requests: [{ number: 1 }],
+  },
+  repository: {
+    name: 'your-repo-name',
+    owner: {
+      login: 'your-repo',
+    },
+  },
+  installation: {
+    id: 2,
+  },
+};
+
+const pullRequestResponse = {
+  number: 1,
+  title: 'Test Pull Request',
+  state: 'open',
+  draft: false,
+  user: {
+    login: 'pr-author',
+    id: 456,
+  },
+  head: {
+    sha: 'abc123',
+  },
+  base: {
+    ref: 'master',
+  },
+  labels: [],
+};
+
+describe('Probot Check Suite Handler', () => {
+  let probot: any;
+
+  afterEach(() => {
+    teardownProbot();
+  });
+
+  test('adds failing CI label when a check run fails', async () => {
+    probot = setupProbot({
+      checkSuites: [{ id: 101 }],
+      checkRunsBySuite: { 101: [{ conclusion: 'failure' }] },
+    });
+
+    const mock = nock('https://api.github.com')
+      .post('/app/installations/2/access_tokens')
+      .reply(200, {
+        token: 'test',
+        permissions: {
+          pull_requests: 'write',
+        },
+      })
+      .get('/repos/your-repo/your-repo-name/pulls/1')
+      .reply(200, pullRequestResponse)
+      .put('/repos/your-repo/your-repo-name/issues/1/labels', (body: any) => {
+        expect(body).toMatchObject({ labels: [labels.failingCI.name] });
+        return true;
+      })
+      .reply(200);
+
+    await probot.receive({
+      name: 'check_suite',
+      payload: checkSuitePayload,
+    });
+
+    expect(mock.pendingMocks()).toStrictEqual([]);
+  });
+
+  test('sets ready for review when CI passes and no reviews', async () => {
+    probot = setupProbot({
+      checkSuites: [{ id: 101 }],
+      checkRunsBySuite: { 101: [{ conclusion: 'success' }] },
+    });
+
+    const mock = nock('https://api.github.com')
+      .post('/app/installations/2/access_tokens')
+      .reply(200, {
+        token: 'test',
+        permissions: {
+          pull_requests: 'write',
+        },
+      })
+      .get('/repos/your-repo/your-repo-name/pulls/1')
+      .reply(200, pullRequestResponse)
+      .get('/repos/your-repo/your-repo-name/pulls/1/reviews')
+      .reply(200, [])
+      .put('/repos/your-repo/your-repo-name/issues/1/labels', (body: any) => {
+        expect(body).toMatchObject({ labels: [labels.readyForReview.name] });
+        return true;
+      })
+      .reply(200);
+
+    await probot.receive({
+      name: 'check_suite',
+      payload: checkSuitePayload,
+    });
+
+    expect(mock.pendingMocks()).toStrictEqual([]);
+  });
+});

--- a/test/checkSuite/checkSuite.test.ts
+++ b/test/checkSuite/checkSuite.test.ts
@@ -62,6 +62,8 @@ describe('Probot Check Suite Handler', () => {
       })
       .get('/repos/your-repo/your-repo-name/pulls/1')
       .reply(200, pullRequestResponse)
+      .get('/repos/your-repo/your-repo-name/pulls/1/reviews')
+      .reply(200, [])
       .put('/repos/your-repo/your-repo-name/issues/1/labels', (body: any) => {
         expect(body).toMatchObject({ labels: [labels.failingCI.name] });
         return true;

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -12,8 +12,45 @@ const privateKey = fs.readFileSync(
   'utf-8',
 );
 
-export const setupProbot = () => {
+type CheckSuite = {
+  id: number;
+};
+
+type ConfigOptions = {
+  enableFailingCI?: boolean;
+  checkSuites?: CheckSuite[];
+  checkRunsBySuite?: Record<number, unknown[]>;
+};
+
+export const mockConfig = ({ enableFailingCI = true }: ConfigOptions = {}) =>
+  nock('https://api.github.com')
+    .persist()
+    .get('/repos/your-repo/your-repo-name/contents/.github%2Factual-gh-bot.yml')
+    .reply(200, `featureFlags:\n  enableFailingCI: ${enableFailingCI}\n`);
+
+export const mockCheckSuites = ({
+  checkSuites = [],
+  checkRunsBySuite = {},
+}: Pick<ConfigOptions, 'checkSuites' | 'checkRunsBySuite'> = {}) => {
+  nock('https://api.github.com')
+    .persist()
+    .get(/\/repos\/your-repo\/your-repo-name\/commits\/[^/]+\/check-suites/)
+    .reply(200, { check_suites: checkSuites });
+
+  for (const suite of checkSuites) {
+    nock('https://api.github.com')
+      .persist()
+      .get(
+        `/repos/your-repo/your-repo-name/check-suites/${suite.id}/check-runs`,
+      )
+      .reply(200, { check_runs: checkRunsBySuite[suite.id] ?? [] });
+  }
+};
+
+export const setupProbot = (options: ConfigOptions = {}) => {
   nock.disableNetConnect();
+  mockConfig(options);
+  mockCheckSuites(options);
   const probot = new Probot({
     appId: 123,
     privateKey,


### PR DESCRIPTION
There have been some intermittent issues where edge cases in event order can lead to labels being removed when they should be retained and vice versa. This PR aims to stop that by taking the full PR state on any major label triggering event and calculating a full set of labels that apply, not assuming which from the event.

I'm hoping to use this as a jumping off point to add some more descriptive labelling like Failing CI and Merge Conflict to prevent PRs being marked as "ready for review" when they're not